### PR TITLE
Align Encode:DSPDC-623

### DIFF
--- a/src/core/DSPCoreDataModel.ttl
+++ b/src/core/DSPCoreDataModel.ttl
@@ -114,6 +114,12 @@ DSPCore:Alignment
   a owl:Class ;
   rdfs:label "Alignment" ;
   rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:Sequencing ;
+  owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
@@ -141,6 +147,12 @@ DSPCore:AlignmentPostProcessing
   a owl:Class ;
   rdfs:label "AlignmentPostProcessing" ;
   rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:Sequencing ;
+  owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
@@ -153,11 +165,16 @@ DSPCore:AlignmentPostProcessing
     ] ;
   skos:prefLabel "AlignmentPostProcessing" ;
 .
-DSPCore:Assay
+DSPCore:AssayActivity
   a owl:Class ;
   rdfs:label "Assay" ;
   rdfs:subClassOf DSPCore:Activity ;
-  owl:equivalentClass obo:OBI_0000070 ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:Sequencing ;
+  owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
@@ -284,32 +301,6 @@ DSPCore:Donor
   skos:definition "An organism from which a sample or test result is available" ;
   skos:prefLabel "Donor" ;
 .
-DSPCore:Experiment
-  a owl:Class ;
-  rdfs:label "Experiment" ;
-  rdfs:subClassOf DSPCore:Activity ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasProtocol ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty prov:generated ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasAssay ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:usesSample ;
-    ] ;
-  skos:prefLabel "Experiment" ;
-.
 DSPCore:File
   a owl:Class ;
   rdfs:comment "Used definition from http://semanticscience.org/resource/SIO_000396 but equivalence to http://www.w3.org/ns/dcat#Distribution doesn't make sense to me; thus we have our own object.  Also added electronic.  This will be subclassed for different file types to allow for file type-specific metadata, but for now, all metadata is an option for all Files." ;
@@ -361,11 +352,6 @@ DSPCore:Library
   rdfs:subClassOf obo:BFO_0000040 ;
   owl:equivalentClass [
       a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty DSPCore:hasExperiment ;
-    ] ;
-  owl:equivalentClass [
-      a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty DSPCore:hasAssay ;
     ] ;
@@ -380,6 +366,12 @@ DSPCore:LibraryPrep
   a owl:Class ;
   rdfs:label "LibraryPrep" ;
   rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:Sequencing ;
+  owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
@@ -408,6 +400,22 @@ DSPCore:NoRestriction
   a obo:DUO_0000004 ;
   rdfs:label "NoRestriction" ;
   skos:prefLabel "NoRestriction" ;
+.
+DSPCore:Pipeline
+  a owl:Class ;
+  rdfs:label "Pipeline" ;
+  rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Sequencing ;
+  owl:disjointWith DSPCore:VariantCalling ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:onProperty prov:used ;
+      owl:someValuesFrom prov:SoftwareAgent ;
+    ] ;
 .
 DSPCore:ReferenceAssembly
   a owl:Class ;
@@ -504,6 +512,12 @@ DSPCore:Sequencing
   a owl:Class ;
   rdfs:label "Sequencing" ;
   rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:VariantCalling ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
@@ -565,6 +579,12 @@ DSPCore:VariantCalling
   a owl:Class ;
   rdfs:label "VariantCalling" ;
   rdfs:subClassOf DSPCore:Activity ;
+  owl:disjointWith DSPCore:Alignment ;
+  owl:disjointWith DSPCore:AlignmentPostProcessing ;
+  owl:disjointWith DSPCore:AssayActivity ;
+  owl:disjointWith DSPCore:LibraryPrep ;
+  owl:disjointWith DSPCore:Pipeline ;
+  owl:disjointWith DSPCore:Sequencing ;
   owl:equivalentClass [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
@@ -691,12 +711,16 @@ DSPCore:hasAntibody
 DSPCore:hasAssay
   a owl:ObjectProperty ;
   rdfs:domain DSPCore:BioSample ;
-  rdfs:domain DSPCore:Experiment ;
-  rdfs:domain DSPCore:Library ;
   rdfs:label "hasAssay" ;
-  rdfs:range DSPCore:Assay ;
+  rdfs:range DSPCore:AssayActivity ;
   rdfs:subPropertyOf prov:hadActivity ;
   skos:prefLabel "hasAssay" ;
+.
+DSPCore:hasAssayType
+  a owl:ObjectProperty ;
+  rdfs:domain DSPCore:AssayActivity ;
+  rdfs:label "hasAssayType" ;
+  rdfs:range obo:OBI_0000070 ;
 .
 DSPCore:hasAverageReadLength
   a owl:DatatypeProperty ;
@@ -797,14 +821,6 @@ DSPCore:hasEthnicity
   rdfs:range xsd:string ;
   skos:prefLabel "hasEthnicity" ;
 .
-DSPCore:hasExperiment
-  a owl:ObjectProperty ;
-  rdfs:domain DSPCore:File ;
-  rdfs:domain DSPCore:Library ;
-  rdfs:label "hasExperiment" ;
-  rdfs:range DSPCore:Experiment ;
-  skos:prefLabel "hasExperiment" ;
-.
 DSPCore:hasFormat
   a owl:DatatypeProperty ;
   rdfs:domain DSPCore:File ;
@@ -863,14 +879,9 @@ DSPCore:hasGrcName
   rdfs:range xsd:string ;
   skos:prefLabel "hasGrcName" ;
 .
-DSPCore:hasLibrary
-  a owl:ObjectProperty ;
-  rdfs:domain DSPCore:BioSample ;
-  rdfs:label "hasLibrary" ;
-.
 DSPCore:hasLibraryPrep
   a owl:ObjectProperty ;
-  rdfs:domain DSPCore:Library ;
+  rdfs:domain DSPCore:BioSample ;
   rdfs:label "hasLibraryPrep" ;
   rdfs:range DSPCore:LibraryPrep ;
   rdfs:subPropertyOf prov:hadActivity ;
@@ -951,8 +962,7 @@ DSPCore:hasPostalCode
 .
 DSPCore:hasProtocol
   a owl:DatatypeProperty ;
-  rdfs:domain DSPCore:Experiment ;
-  rdfs:domain obo:OBI_0000070 ;
+  rdfs:domain DSPCore:Activity ;
   rdfs:label "hasProtocol" ;
   rdfs:range xsd:string ;
   rdfs:subPropertyOf prov:used ;
@@ -1063,8 +1073,7 @@ DSPCore:hasStopPosition
 DSPCore:hasTarget
   a owl:DatatypeProperty ;
   rdfs:comment "Target is a string for now but will ultimately be a class." ;
-  rdfs:domain DSPCore:Experiment ;
-  rdfs:domain obo:OBI_0000070 ;
+  rdfs:domain DSPCore:AssayActivity ;
   rdfs:label "hasTarget" ;
   rdfs:range xsd:string ;
   skos:prefLabel "hasTarget" ;
@@ -1125,7 +1134,6 @@ DSPCore:isPairedEnd
 .
 DSPCore:usesSample
   a owl:ObjectProperty ;
-  rdfs:domain DSPCore:Experiment ;
   rdfs:label "usesSample" ;
   rdfs:range DSPCore:BioSample ;
   rdfs:subPropertyOf prov:used ;
@@ -1159,7 +1167,7 @@ obo:NCBITaxon_9606
   skos:definition "Instance of Homo sapiens organism to define organism type." ;
 .
 obo:OBI_0000070
-  owl:equivalentClass DSPCore:Assay ;
+  owl:equivalentClass DSPCore:AssayActivity ;
 .
 prov:Agent
   owl:equivalentClass <http://xmlns.com/foaf/0.1/Agent> ;

--- a/src/extensions/epigenomics/Encode.ttl
+++ b/src/extensions/epigenomics/Encode.ttl
@@ -53,14 +53,25 @@ Encode:Age_1
   rdfs:label "Age_1" ;
   skos:prefLabel "Age_1" ;
 .
+Encode:Assay_for_ENCSR895SFC
+  a <http://datamodel.terra.bio/DSPCore#AssayActivity> ;
+  <http://datamodel.terra.bio/DSPCore#hasAssayType> Encode:OBI_0002142_1 ;
+  <http://datamodel.terra.bio/DSPCore#hasProtocol> "https://www.encodeproject.org/documents/d90ef931-e735-4b25-a7f8-6ddbcaea71dd/@@download/attachment/NanoString%20miRNA%20Assay.pdf" ;
+  <http://datamodel.terra.bio/DSPCore#hasTarget> "http://www.encodeproject.org/targets/STAT5A-human/" ;
+  Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX51-52-nanostring" ;
+  rdfs:label "Assay_for_ENCSR895SFC" ;
+  prov:generated Encode:ENCFF488IYR ;
+  prov:generated Encode:ENCFF660GHH ;
+  prov:used Encode:ENCLB011GAL ;
+.
 Encode:ENCBS562VSE
   a <http://datamodel.terra.bio/DSPCore#BioSample> ;
   DSPCore:dateObtained "2015-10-30T00:00:00"^^xsd:dateTime ;
+  DSPCore:derived Encode:ENCBS719AMH ;
   DSPCore:donatedBy Encode:ENCD0451RUA ;
   DSPCore:hasAnatomicSite "UBERON:0002369" ;
-  DSPCore:hasBioSampleType "tissue" ;
+  DSPCore:hasBioSampleType <http://datamodel.broadinstitute.org/DSPCoreValueSets#Tissue> ;
   DSPCore:hasConsentCode DSPCore:NoRestriction ;
-  DSPCore:derived Encode:ENCBS719AMH ;
   dcterms:source "http://www.encodeproject.org/sources/kristin-ardlie/" ;
   rdfs:label "ENCBS562VSE" ;
   skos:prefLabel "ENCBS562VSE" ;
@@ -115,6 +126,7 @@ Encode:ENCFF043TPA
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF043TPA/"^^dcterms:URI ;
   DSPCore:hasFormat "bidBed" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF043TPA" ;
   skos:prefLabel "ENCFF043TPA" ;
 .
@@ -122,6 +134,7 @@ Encode:ENCFF147BDY
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF147BDY/"^^dcterms:URI ;
   DSPCore:hasFormat "bidBed" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF147BDY" ;
   skos:prefLabel "ENCFF147BDY" ;
 .
@@ -129,6 +142,7 @@ Encode:ENCFF213BVA
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF213BVA/"^^dcterms:URI ;
   DSPCore:hasFormat "bed" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF213BVA" ;
   skos:prefLabel "ENCFF213BVA" ;
 .
@@ -136,6 +150,7 @@ Encode:ENCFF424QYJ
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF424QYJ/"^^dcterms:URI ;
   DSPCore:hasFormat "bed" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF424QYJ" ;
   skos:prefLabel "ENCFF424QYJ" ;
 .
@@ -143,6 +158,7 @@ Encode:ENCFF488IYR
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF488IYR/"^^dcterms:URI ;
   DSPCore:hasFormat "rcc" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF488IYR" ;
   skos:prefLabel "ENCFF488IYR" ;
 .
@@ -150,16 +166,15 @@ Encode:ENCFF660GHH
   a <http://datamodel.terra.bio/DSPCore#File> ;
   DSPCore:hasCrossReference "https://www.encodeproject.org/files/ENCFF660GHH/"^^dcterms:URI ;
   DSPCore:hasFormat "rcc" ;
+  <http://datamodel.terra.bio/DSPCore#hasDataModality> <http://datamodel.broadinstitute.org/DSPCoreValueSets#MicroRNACounts> ;
   rdfs:label "ENCFF660GHH" ;
   skos:prefLabel "ENCFF660GHH" ;
 .
 Encode:ENCLB011GAL
   a DSPCore:Library ;
-  DSPCore:hasAssay Encode:OBI_0002142_1 ;
   DSPCore:hasCrossReference "http://www.encodeproject.org/libraries/ENCLB011GAL/"^^dcterms:URI ;
   Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX52-Lib2" ;
   Encode:hasLab "http://www.encodeproject.org/labs/ali-mortazavi/" ;
-  Encode:hasStatus "released" ;
   Encode:strandSpecificity false ;
   Encode:submittedBy "http://www.encodeproject.org/users/bc5b62f7-ce28-4a1e-b6b3-81c9c5a86d7a/" ;
   dcterms:created "2016-07-25T22:17:41.258151+00:00" ;
@@ -167,18 +182,19 @@ Encode:ENCLB011GAL
   skos:prefLabel "ENCLB011GAL" ;
 .
 Encode:ENCSR895SFC
-  a <http://datamodel.terra.bio/DSPCore#Experiment> ;
+  a Encode:Experiment ;
   DSPCore:dateReleased "2016-08-01T00:00:00"^^xsd:dateTime ;
-  DSPCore:generated Encode:ENCLB011GAL ;
   DSPCore:hasCrossReference "http://www.encodeproject.org/experiments/ENCSR895SFC"^^dcterms:URI ;
-  DSPCore:hasTarget "http://www.encodeproject.org/targets/STAT5A-human/" ;
   DSPCore:usesSample Encode:ENCBS719AMH ;
-  Encode:hasAlias "ali-mortazavi: human-adrenal-gland-ENTEX51-52-nanostring" ;
+  <http://datamodel.terra.bio/DSPCore#hasAssay> Encode:Assay_for_ENCSR895SFC ;
+  Encode:hasLibrary Encode:ENCLB011GAL ;
   Encode:hasStatus "released" ;
   dcterms:created "2016-07-25T22:17:18.167352+00" ;
   dcterms:dateSubmitted "2016-07-31" ;
   rdfs:label "ENCSR895SFC" ;
-  skos:prefLabel "ENCSR895SFS" ;
+  skos:prefLabel "ENCSR895SFC" ;
+  prov:hadActivity Encode:MortazaviLab_NanoStringPipeline ;
+  prov:used Encode:ENCBS719AMH ;
 .
 Encode:EncodeDataset
   a DSPdcat_ap:Dataset ;
@@ -188,6 +204,22 @@ Encode:EncodeDataset
   dcterms:hasPart Encode:ENCD0451RUA ;
   rdfs:label "EncodeDataset" ;
   skos:prefLabel "EncodeDataset" ;
+.
+Encode:Experiment
+  a owl:Class ;
+  rdfs:label "Experiment" ;
+  rdfs:subClassOf <http://datamodel.terra.bio/DSPCore#Activity> ;
+.
+Encode:MortazaviLab_NanoStringPipeline
+  a <http://datamodel.terra.bio/DSPCore#Pipeline> ;
+  <http://datamodel.terra.bio/DSPCore#hasProtocol> "https://www.encodeproject.org/documents/01810c91-4873-4268-b6a4-7e3e7c620fe0/@@download/attachment/nanostring_pipeline_overview_V1.png" ;
+  rdfs:label "Pipeline" ;
+  prov:generated Encode:ENCFF043TPA ;
+  prov:generated Encode:ENCFF147BDY ;
+  prov:generated Encode:ENCFF213BVA ;
+  prov:generated Encode:ENCFF424QYJ ;
+  prov:used Encode:ENCFF488IYR ;
+  prov:used Encode:ENCFF660GHH ;
 .
 Encode:OBI_0002142_1
   a obo:OBI_0002142 ;
@@ -224,6 +256,12 @@ Encode:hasDataQuality
   rdfs:range xsd:string ;
   skos:prefLabel "hasDataQuality" ;
 .
+Encode:hasExperiment
+  a owl:ObjectProperty ;
+  rdfs:domain <http://datamodel.terra.bio/DSPCore#BioSample> ;
+  rdfs:label "hasExperiment" ;
+  rdfs:range Encode:Experiment ;
+.
 Encode:hasLab
   a owl:DatatypeProperty ;
   rdfs:label "hasLab" ;
@@ -233,6 +271,7 @@ Encode:hasLab
 Encode:hasLibrary
   a owl:ObjectProperty ;
   rdfs:domain <http://datamodel.terra.bio/DSPCore#BioSample> ;
+  rdfs:domain Encode:Experiment ;
   rdfs:label "hasLibrary" ;
   rdfs:range <http://datamodel.terra.bio/DSPCore#Library> ;
 .


### PR DESCRIPTION
**DSPCoreDataModel.ttl**

- Removed Experiment (likely only used by Encode)
- Defined Activity subclasses as Disjoint to ensure they couldn’t be 2 types of activity at once.  Added Pipeline Activity to more accurately capture experiment components; will need this for other software pipelines.
- Changed Assay class name to AssayActivity to avoid confusion with assay removed it as an equivalent class of assay.  
- Moved hasLibrary into Encode; not sure this will be used by other datasets.

**Encode.ttl**

- Moved Experiment and hasLibrary into Encode
- Extend DSPCore:hasAssay to allow Experiments to have assays too.
- Example changes
-- Created Assay instance rather than using the Experiment to capture Assay metadata
-- Added Data Modality and BioSampleType
-- Status “released” belongs to the Experiment, not the Library
-- Target belongs to Assay not Experiment